### PR TITLE
Support for multiple attributes

### DIFF
--- a/TGBotFramework/BotFramework/Attributes/BaseAttribute.cs
+++ b/TGBotFramework/BotFramework/Attributes/BaseAttribute.cs
@@ -2,10 +2,12 @@
 
 namespace BotFramework.Attributes
 {
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public abstract class HandlerAttribute: Attribute
     {
         protected abstract bool CanHandle(HandlerParams param);
         internal bool CanHandleInternal(HandlerParams param) => CanHandle(param);
+
+        public override object TypeId => Guid.NewGuid();
     }
 }

--- a/TGBotFramework/BotFramework/Attributes/CommandAttribute.cs
+++ b/TGBotFramework/BotFramework/Attributes/CommandAttribute.cs
@@ -12,7 +12,7 @@ namespace BotFramework.Attributes
         internal bool IsParametrized = false;
         public CommandAttribute()
         {
-            MessageFlags = MessageFlag.HasText | MessageFlag.HasCaption;
+            MessageFlags = MessageFlag.HasEntity;
             IsCommand = true;
         }
 

--- a/TGBotFramework/BotFramework/Attributes/HandleConditionAttribute.cs
+++ b/TGBotFramework/BotFramework/Attributes/HandleConditionAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace BotFramework.Attributes;
+
+public enum ConditionType
+{
+    Any,
+    All
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+public class HandleConditionAttribute : Attribute
+{
+    public ConditionType ConditionType { get; set; }
+    public HandleConditionAttribute(ConditionType conditionType)
+    {
+        ConditionType = conditionType;
+    }
+}
+

--- a/TGBotFramework/BotFramework/Attributes/MessageAttribute.cs
+++ b/TGBotFramework/BotFramework/Attributes/MessageAttribute.cs
@@ -4,9 +4,11 @@ using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
 
 namespace BotFramework.Attributes
 {
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public class MessageAttribute: UpdateAttribute
     {
         internal MessageFlag MessageFlags;
@@ -61,6 +63,7 @@ namespace BotFramework.Attributes
 
             var message = param.Update.Message;
 
+
             if(message != null && CanHandleMessage(message))
             {
                 var text = message.Text ?? message.Caption;
@@ -79,10 +82,6 @@ namespace BotFramework.Attributes
 
         private bool CanHandleMessage(Message message)
         {
-            if(MessageFlags.HasFlag(MessageFlag.All))
-            {
-                return true;
-            }
 
             return (from object f in Enum.GetValues(typeof(MessageFlag))
                     where MessageFlags.HasFlag((Enum)f)
@@ -126,6 +125,18 @@ namespace BotFramework.Attributes
                             MessageFlag.HasSuccessfulPayment => message.SuccessfulPayment != null,
                             _ => false
                         }).Any(ret => ret);
+                    return true;
+            }
+            return false;
+                    return true;
+            }
+            return false;
+                    return true;
+            }
+            return false;
+                    return true;
+            }
+            return false;
         }
 
         private bool IsTextMatch(string text)

--- a/TGBotFramework/BotFramework/Attributes/MessageAttribute.cs
+++ b/TGBotFramework/BotFramework/Attributes/MessageAttribute.cs
@@ -82,61 +82,47 @@ namespace BotFramework.Attributes
 
         private bool CanHandleMessage(Message message)
         {
-
-            return (from object f in Enum.GetValues(typeof(MessageFlag))
-                    where MessageFlags.HasFlag((Enum)f)
-                    select f switch
-                        {
-                            MessageFlag.HasForward => message.ForwardFrom != null || message.ForwardFromChat != null,
-                            MessageFlag.IsReply => message.ReplyToMessage != null,
-                            MessageFlag.HasText => !string.IsNullOrEmpty(message.Text),
-                            MessageFlag.HasEntity => message.Entities != null || message.CaptionEntities != null,
-                            MessageFlag.HasVoice => message.Voice != null,
-                            MessageFlag.HasAudio => message.Audio != null,
-                            MessageFlag.HasVideo => message.Video != null,
-                            MessageFlag.HasDocument => message.Document != null,
-                            MessageFlag.HasAnimation => message.Animation != null,
-                            MessageFlag.HasGame => message.Game != null,
-                            MessageFlag.HasCaption => !string.IsNullOrEmpty(message.Caption),
-                            MessageFlag.HasPhoto => message.Photo != null,
-                            MessageFlag.HasSticker => message.Sticker != null,
-                            MessageFlag.HasVideoNote => message.VideoNote != null,
-                            MessageFlag.HasContact => message.Contact != null,
-                            MessageFlag.HasLocation => message.Location != null,
-                            MessageFlag.HasVenue => message.Venue != null,
-                            MessageFlag.HasPoll => message.Poll != null,
-                            MessageFlag.HasDice => message.Dice != null,
-                            MessageFlag.HasKeyboard => message.ReplyMarkup != null,
-                            MessageFlag.HasNewChatMembers => message.NewChatMembers?.Any() == true,
-                            MessageFlag.HasLeftChatMember => message.LeftChatMember != null,
-                            MessageFlag.HasNewChatTitle => !string.IsNullOrEmpty(message.NewChatTitle),
-                            MessageFlag.HasNewChatPhoto => message.NewChatPhoto != null,
-                            MessageFlag.HasDeleteChatPhoto => message.DeleteChatPhoto != null,
-                            MessageFlag.HasGroupChatCreated => message.GroupChatCreated != null,
-                            MessageFlag.HasSupergroupChatCreated => message.SupergroupChatCreated != null,
-                            MessageFlag.HasPinnedMessage => message.PinnedMessage != null,
-                            MessageFlag.HasVideoChatScheduled => message.VideoChatScheduled != null,
-                            MessageFlag.HasVideoChatStarted => message.VideoChatStarted != null,
-                            MessageFlag.HasVideoChatEnded => message.VideoChatEnded != null,
-                            MessageFlag.HasVideoChatParticipantsInvited => message.VideoChatParticipantsInvited != null,
-                            MessageFlag.HasMediaSpoiler => message.HasMediaSpoiler ?? false,
-                            MessageFlag.HasInvoice => message.Invoice != null,
-                            MessageFlag.HasPassportData => message.PassportData != null,
-                            MessageFlag.HasSuccessfulPayment => message.SuccessfulPayment != null,
-                            _ => false
-                        }).Any(ret => ret);
-                    return true;
-            }
-            return false;
-                    return true;
-            }
-            return false;
-                    return true;
-            }
-            return false;
-                    return true;
-            }
-            return false;
+            return MessageFlags switch
+                {
+                    MessageFlag.All => true,
+                    MessageFlag.HasForward => message.ForwardFrom != null || message.ForwardFromChat != null,
+                    MessageFlag.IsReply => message.ReplyToMessage != null,
+                    MessageFlag.HasText => !string.IsNullOrEmpty(message.Text),
+                    MessageFlag.HasEntity => message.Entities != null || message.CaptionEntities != null,
+                    MessageFlag.HasVoice => message.Voice != null,
+                    MessageFlag.HasAudio => message.Audio != null,
+                    MessageFlag.HasVideo => message.Video != null,
+                    MessageFlag.HasDocument => message.Document != null,
+                    MessageFlag.HasAnimation => message.Animation != null,
+                    MessageFlag.HasGame => message.Game != null,
+                    MessageFlag.HasCaption => !string.IsNullOrEmpty(message.Caption),
+                    MessageFlag.HasPhoto => message.Photo != null,
+                    MessageFlag.HasSticker => message.Sticker != null,
+                    MessageFlag.HasVideoNote => message.VideoNote != null,
+                    MessageFlag.HasContact => message.Contact != null,
+                    MessageFlag.HasLocation => message.Location != null,
+                    MessageFlag.HasVenue => message.Venue != null,
+                    MessageFlag.HasPoll => message.Poll != null,
+                    MessageFlag.HasDice => message.Dice != null,
+                    MessageFlag.HasKeyboard => message.ReplyMarkup != null,
+                    MessageFlag.HasNewChatMembers => message.NewChatMembers?.Any() == true,
+                    MessageFlag.HasLeftChatMember => message.LeftChatMember != null,
+                    MessageFlag.HasNewChatTitle => !string.IsNullOrEmpty(message.NewChatTitle),
+                    MessageFlag.HasNewChatPhoto => message.NewChatPhoto != null,
+                    MessageFlag.HasDeleteChatPhoto => message.DeleteChatPhoto != null,
+                    MessageFlag.HasGroupChatCreated => message.GroupChatCreated != null,
+                    MessageFlag.HasSupergroupChatCreated => message.SupergroupChatCreated != null,
+                    MessageFlag.HasPinnedMessage => message.PinnedMessage != null,
+                    MessageFlag.HasVideoChatScheduled => message.VideoChatScheduled != null,
+                    MessageFlag.HasVideoChatStarted => message.VideoChatStarted != null,
+                    MessageFlag.HasVideoChatEnded => message.VideoChatEnded != null,
+                    MessageFlag.HasVideoChatParticipantsInvited => message.VideoChatParticipantsInvited != null,
+                    MessageFlag.HasMediaSpoiler => message.HasMediaSpoiler ?? false,
+                    MessageFlag.HasInvoice => message.Invoice != null,
+                    MessageFlag.HasPassportData => message.PassportData != null,
+                    MessageFlag.HasSuccessfulPayment => message.SuccessfulPayment != null,
+                    _ => false
+                };
         }
 
         private bool IsTextMatch(string text)

--- a/TGBotFramework/BotFramework/BotEventHandler.cs
+++ b/TGBotFramework/BotFramework/BotEventHandler.cs
@@ -1,15 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Reflection;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
-using BotFramework.Abstractions;
+﻿using BotFramework.Abstractions;
 using BotFramework.Attributes;
 using BotFramework.Enums;
-using BotFramework.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 using Telegram.Bot;
 using Telegram.Bot.Types;
 
@@ -53,7 +50,6 @@ namespace BotFramework
 
     internal class EventHandlerFactory
     {
-        //private readonly List<EventHandler> handlers = new List<EventHandler>();
         private readonly List<Method> _methods = new();
         
         public void Find()

--- a/TGBotFramework/BotFramework/BotEventHandler.cs
+++ b/TGBotFramework/BotFramework/BotEventHandler.cs
@@ -131,11 +131,13 @@ namespace BotFramework
             {
                 if(method.ConditionType == ConditionType.Any)
                 {
-                    availableHandlers.AddRange(method.Handlers.Where(handler => handler.Attribute.CanHandleInternal(param)));
+                    var handlers = method.Handlers.Where(handler => handler.Attribute.CanHandleInternal(param));
+                    if(handlers.Any())
+                        availableHandlers.Add(handlers.First());
                 }
                 else if(method.Handlers.All(handler => handler.Attribute.CanHandleInternal(param)))
                 {
-                    availableHandlers.AddRange(method.Handlers);
+                    availableHandlers.Add(method.Handlers.FirstOrDefault());
                 }
             }
 

--- a/TGBotFramework/BotFramework/BotEventHandler.cs
+++ b/TGBotFramework/BotFramework/BotEventHandler.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using BotFramework.Abstractions;
 using BotFramework.Attributes;
@@ -34,17 +36,26 @@ namespace BotFramework
     internal class EventHandler
     {
         public HandlerAttribute Attribute;
-        public short Priority;
-        public MethodInfo Method;
         public Type MethodOwner;
+        public MethodInfo Method;
         public ParameterInfo[] Parameters;
         public bool Parametrized;
     }
 
+    internal class Method
+    {
+        public List<EventHandler> Handlers = new();
+        public MethodInfo Info;
+        public short Priority;
+        public Type Owner;
+        public ConditionType ConditionType;
+    }
+
     internal class EventHandlerFactory
     {
-        private readonly List<EventHandler> handlers = new List<EventHandler>();
-
+        //private readonly List<EventHandler> handlers = new List<EventHandler>();
+        private readonly List<Method> _methods = new();
+        
         public void Find()
         {
             var knowHandlers = new List<Type>();
@@ -56,6 +67,7 @@ namespace BotFramework
 
 
             foreach(var assembly in assemblies)
+            {
                 try
                 {
                     var types = assembly.GetTypes()
@@ -63,43 +75,73 @@ namespace BotFramework
                     knowHandlers.AddRange(types);
 
                 } catch(ReflectionTypeLoadException) { }
+            }
+
 
             foreach(var handler in knowHandlers)
             {
-                var methods = handler.GetMethods().Where(x => x.GetCustomAttributes<HandlerAttribute>().Any());
+                var methods = handler.GetMethods().Where(x => 
+                    x.GetCustomAttributes<HandlerAttribute>().Any());
 
                 foreach(var methodInfo in methods)
                 {
                     var priority = methodInfo.GetCustomAttribute<PriorityAttribute>();
                     if(priority != null && methodInfo.ReturnType != typeof(Task<bool>))
+                    {
                         throw new Exception($"Method {methodInfo.Name} should return Task<bool> when priority attribute used");
+                    }
 
-                    var eHandler = new EventHandler
+                    var conditionType = methodInfo.GetCustomAttribute<HandleConditionAttribute>()?.ConditionType ??
+                                        ConditionType.Any;
+
+                    var method = new Method 
                         {
-                            Attribute = methodInfo.GetCustomAttribute<HandlerAttribute>(),
+                            Info = methodInfo,
                             Priority = priority?.Value ?? 0,
-                            Method = methodInfo,
-                            MethodOwner = handler,
+                            ConditionType = conditionType,
+                            Owner = handler
+
                         };
-                    eHandler.Parametrized = eHandler.Attribute is ParametrizedCommandAttribute;
-                    eHandler.Parameters = methodInfo.GetParameters();
-                    handlers.Add(eHandler);
+
+                    var attributes = methodInfo.GetCustomAttributes<HandlerAttribute>();
+                    foreach(var attribute in attributes)
+                    {
+                        var eHandler = new EventHandler 
+                            {
+                                Attribute = attribute,
+                                MethodOwner = handler,
+                                Method = methodInfo
+                            };
+
+                        eHandler.Parametrized = eHandler.Attribute is ParametrizedCommandAttribute;
+                        eHandler.Parameters = methodInfo.GetParameters();
+                        method.Handlers.Add(eHandler);
+                    }
+                    _methods.Add(method);
                 }
             }
         }
 
         public async Task ExecuteHandler(HandlerParams param)
         {
-            HandlerExec executed;
 
-            var availableHandlers = handlers
-                .Where(x => x.Attribute.CanHandleInternal(param))
-                .OrderByDescending(x => x.Priority)
-                .ToList();
+            var methods = _methods.OrderByDescending(m => m.Priority);// in case handlers was added in runtime
+            var availableHandlers = new List<EventHandler>();
+            foreach(var method in methods)
+            {
+                if(method.ConditionType == ConditionType.Any)
+                {
+                    availableHandlers.AddRange(method.Handlers.Where(handler => handler.Attribute.CanHandleInternal(param)));
+                }
+                else if(method.Handlers.All(handler => handler.Attribute.CanHandleInternal(param)))
+                {
+                    availableHandlers.AddRange(method.Handlers);
+                }
+            }
 
             foreach(var eventHandler in availableHandlers)
             {
-                executed = await Exec(eventHandler, param);
+                var executed = await Exec(eventHandler, param);
                 switch(executed)
                 {
                     case HandlerExec.Break:
@@ -119,7 +161,7 @@ namespace BotFramework
 
             try
             {
-                var instance = (BotEventHandler)ActivatorUtilities.CreateInstance(provider, method.DeclaringType);
+                var instance = (BotEventHandler)ActivatorUtilities.CreateInstance(provider, handler.MethodOwner);
                 instance.__Instantiate(param);
                 object[] paramObjects;
                 if(handler.Parameters.Length > 0 && handler.Parametrized && param.IsParametrizedCommand)
@@ -143,23 +185,24 @@ namespace BotFramework
                 {
                     paramObjects = null;
                 }
-
-                if(method.ReturnParameter.ParameterType == typeof(Task))
+                var task = method.Invoke(instance, paramObjects);
+                if(task == null)
                 {
-                    var task = method.Invoke(instance, paramObjects);
+                    return HandlerExec.Continue;
+                }
+
+                if(method.ReturnParameter?.ParameterType == typeof(Task))
+                {
+                    
                     await (Task)task;
                     return HandlerExec.Continue;
                 }
 
-                if(method.ReturnParameter.ParameterType == typeof(Task<bool>))
+                if(method.ReturnParameter?.ParameterType == typeof(Task<bool>))
                 {
-                    var task = method.Invoke(instance, paramObjects);
                     return await (Task<bool>)task ? HandlerExec.Continue : HandlerExec.Break;
                 }
 
-
-                method.Invoke(instance, paramObjects);
-                return HandlerExec.Continue;
             } catch(ArgumentException e)
             {
                 Console.WriteLine(e);

--- a/TGBotFramework/BotFramework/HandlerParams.cs
+++ b/TGBotFramework/BotFramework/HandlerParams.cs
@@ -167,6 +167,7 @@ namespace BotFramework
             {
                 var fulltext = message.EntityValues?.FirstOrDefault() ??
                                message.CaptionEntityValues?.FirstOrDefault();
+                
 
                 var ent = message.Entities?.FirstOrDefault() ?? message.CaptionEntities?.FirstOrDefault();
                 ParametrizedCmd = new ParametrizedCommand

--- a/TGBotFramework/Examples/BotAsWorkerService/BotAsWorkerService.csproj
+++ b/TGBotFramework/Examples/BotAsWorkerService/BotAsWorkerService.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TGBotFramework/Examples/BotAsWorkerService/BotAsWorkerService.csproj
+++ b/TGBotFramework/Examples/BotAsWorkerService/BotAsWorkerService.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TGBotFramework/Examples/BotAsWorkerService/EventHandler.cs
+++ b/TGBotFramework/Examples/BotAsWorkerService/EventHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using BotFramework;
 using BotFramework.Attributes;
@@ -7,8 +8,14 @@ using BotFramework.Setup;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using BotFramework.Enums;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Webp;
 using Telegram.Bot;
+using Telegram.Bot.Types.InputFiles;
 using Telegram.Bot.Types.ReplyMarkups;
+using File = System.IO.File;
+using System.Diagnostics;
 
 namespace BotAsWorkerService
 {
@@ -88,19 +95,23 @@ namespace BotAsWorkerService
             await Bot.SendTextMessageAsync(Chat, "Command1");
         }
 
+        [Message(MessageFlag.IsReply)]
         [Command("command2")]
         public async Task Command2()
         {
             await Bot.SendTextMessageAsync(Chat, "Command2");
         }
 
-        [Command("spoiler")]
-        public async Task Spoiler()
+        [Message(MessageFlag.HasPhoto)]
+        [Message(MessageFlag.HasSticker)]
+        [Update(InChat.All, UpdateFlag.Message)]
+        [Message(MessageFlag.HasText)]
+        public async Task<bool> MultiAttr()
         {
-            await Bot.SendAnimationAsync(Chat.Id, animation: new InputFileUrl(@"https://file-examples.com/storage/fecd197fb063b33dd9d79e6/2017/04/file_example_MP4_480_1_5MG.mp4"), hasSpoiler: true);
+            await Bot.SendTextMessageAsync(Chat.Id, "multi attributes");
+            return false;
         }
-        
-        
+
     }
 
     public class MeParam

--- a/TGBotFramework/Examples/BotAsWorkerService/EventHandler.cs
+++ b/TGBotFramework/Examples/BotAsWorkerService/EventHandler.cs
@@ -93,7 +93,7 @@ namespace BotAsWorkerService
             await Bot.SendTextMessageAsync(Chat, "Command2");
         }
 
-/*        [HandleCondition(ConditionType.Any)]
+        [HandleCondition(ConditionType.Any)]
         [Message(MessageFlag.HasPhoto)]
         [Message(MessageFlag.HasSticker)]
         [Update(InChat.All, UpdateFlag.Message)]
@@ -102,7 +102,7 @@ namespace BotAsWorkerService
         {
             await Bot.SendTextMessageAsync(Chat.Id, "multi attributes");
             return true;
-        }*/
+        }
 
         [HandleCondition(ConditionType.All)]
         [Message(MessageFlag.HasPhoto)]

--- a/TGBotFramework/Examples/BotAsWorkerService/EventHandler.cs
+++ b/TGBotFramework/Examples/BotAsWorkerService/EventHandler.cs
@@ -1,21 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using BotFramework;
+﻿using BotFramework;
 using BotFramework.Attributes;
-using BotFramework.Setup;
+using BotFramework.Enums;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Telegram.Bot;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
-using BotFramework.Enums;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.Formats.Webp;
-using Telegram.Bot;
-using Telegram.Bot.Types.InputFiles;
 using Telegram.Bot.Types.ReplyMarkups;
-using File = System.IO.File;
-using System.Diagnostics;
 
 namespace BotAsWorkerService
 {
@@ -102,6 +93,7 @@ namespace BotAsWorkerService
             await Bot.SendTextMessageAsync(Chat, "Command2");
         }
 
+/*        [HandleCondition(ConditionType.Any)]
         [Message(MessageFlag.HasPhoto)]
         [Message(MessageFlag.HasSticker)]
         [Update(InChat.All, UpdateFlag.Message)]
@@ -109,7 +101,16 @@ namespace BotAsWorkerService
         public async Task<bool> MultiAttr()
         {
             await Bot.SendTextMessageAsync(Chat.Id, "multi attributes");
-            return false;
+            return true;
+        }*/
+
+        [HandleCondition(ConditionType.All)]
+        [Message(MessageFlag.HasPhoto)]
+        [Message(MessageFlag.HasCaption)]
+        public async Task<bool> MultiAttr2()
+        {
+            await Bot.SendTextMessageAsync(Chat.Id, "Message with photo AND caption");
+            return true;
         }
 
     }


### PR DESCRIPTION
Instead of different message flags, use different attributes:
``` c#
        [Message(MessageFlag.HasPhoto)]
        [Message(MessageFlag.HasSticker)]
        [Update(InChat.All, UpdateFlag.Message)]
        [Message(MessageFlag.HasText)]
        public async Task<bool> MultiAttr()
        {
            await Bot.SendTextMessageAsync(Chat.Id, "multi attributes");
            return true;
        }
```

New attribute `HandleCondition` to determine whether only one(Any) or every(All) attributes will trigger handler method:
```     c#
        [HandleCondition(ConditionType.All)] //<==
        [Message(MessageFlag.HasPhoto)]
        [Message(MessageFlag.HasCaption)]
        public async Task<bool> MultiAttr2()
        {
            await Bot.SendTextMessageAsync(Chat.Id, "Message with photo AND caption");
            return true;
        }
```
Default is Any (old behaviour)

### !!!
**This PR changes MessageFlag behaviour to handle multiple flags.** 
`[Message(MessageFlag.HasPhoto | MessageFlag.HasCaption)]` - now will be triggered when both conditions are satisfied, not any